### PR TITLE
Retry on HTTP 500

### DIFF
--- a/src/HttpSkipResponseCommand.cc
+++ b/src/HttpSkipResponseCommand.cc
@@ -220,6 +220,7 @@ bool HttpSkipResponseCommand::processResponse()
       }
       throw DL_RETRY_EX2(MSG_RESOURCE_NOT_FOUND,
                          error_code::RESOURCE_NOT_FOUND);
+    case 500:
     case 502:
     case 503:
       // Only retry if pretry-wait > 0. Hammering 'busy' server is not


### PR DESCRIPTION
AWS S3 recommends retries on both 500 and 503 HTTP response status codes https://aws.amazon.com/premiumsupport/knowledge-center/http-5xx-errors-s3/